### PR TITLE
feat: Add pack download and switching functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ What this implements
 Commands
 --------
 
-*   `Peon Ping: Install Copilot Hooks`
-*   `Peon Ping: Remove Copilot Hooks`
-*   `Peon Ping: Open Hook Config`
-*   `Peon Ping: Toggle Enabled`
-*   `Peon Ping: Sync Default Audio Pack`
+*   `Peon Ping: Install Copilot Hooks` - Set up hooks and download the default peon pack
+*   `Peon Ping: Remove Copilot Hooks` - Remove hook files (preserves config and packs)
+*   `Peon Ping: Open Hook Config` - Edit configuration settings
+*   `Peon Ping: Toggle Enabled` - Quickly enable/disable sounds
+*   `Peon Ping: Sync Default Audio Pack` - Re-download the peon pack
+*   `Peon Ping: Download & Activate Sound Pack` - Browse and download any the available packs from the upstream peon-ping registry
+*   `Peon Ping: Switch Active Pack` - Switch between your installed packs
 
 Installed files
 ---------------

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "onCommand:peonPing.removeHooks",
     "onCommand:peonPing.openConfig",
     "onCommand:peonPing.toggleEnabled",
-    "onCommand:peonPing.syncDefaultPack"
+    "onCommand:peonPing.syncDefaultPack",
+    "onCommand:peonPing.downloadPack",
+    "onCommand:peonPing.switchPack"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -40,6 +42,14 @@
       {
         "command": "peonPing.syncDefaultPack",
         "title": "Peon Ping: Sync Default Audio Pack"
+      },
+      {
+        "command": "peonPing.downloadPack",
+        "title": "Peon Ping: Download & Activate Sound Pack"
+      },
+      {
+        "command": "peonPing.switchPack",
+        "title": "Peon Ping: Switch Active Pack"
       }
     ]
   },


### PR DESCRIPTION
# Pull Request Review - Pack Download & Switching Feature

Hello, thanks for putting this out there!

I've been using it, it's fun, but I had always intended to use a different voice pack from the upstream peon-ping, (tf2_engineer), and thought that while I was at it, I ought to use the opportunity to add a quick switch command.

So, this PR adds the ability to browse, download, and switch between sound packs which are already in the upstream PeonPing registry using the cmd+p menu.

It also displays a lot of the metadata from the registry to the quick pick menu, to help see how many sounds are in each pack, what language they're in , etc.